### PR TITLE
Flatten multiline title cells in series README tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,9 +121,7 @@ The master catalog is **[`catalog/catalog.csv`](./catalog/catalog.csv)** with fi
 | Strains In Soviet-East German Relations: 1962-1967 | CAESAR | [caesar-42](caesar/1967/caesar-42.md) | 115 | SECRET | [PDF](https://www.cia.gov/readingroom/docs/caesar-42.pdf) | 1967 |
 | The Sino-Soviet Dispute Within The Communist Movement In Latin America | ESAU | [esau-32](esau/1967/esau-32.md) | 187 | Top Secret | [PDF](https://www.cia.gov/readingroom/docs/esau-32.pdf) | 1967 |
 | Policy And Politics In The Cpsu Politburo: October 1964 To September 1967 | CAESAR | [caesar-43](caesar/1967/caesar-43.md) | 103 | Secret | [PDF](https://www.cia.gov/readingroom/docs/caesar-43.pdf) | 1967 |
-| The Sino-Soviet Struggle
-In The World Communist Movement
-Since Khrushchev’S Fall (Part 3) | ESAU | [esau-35](esau/1967/esau-35.md) | 206 | Top Secret | [PDF](https://www.cia.gov/readingroom/docs/esau-35.pdf) | 1967 |
+| The Sino-Soviet Struggle In The World Communist Movement Since Khrushchev’S Fall (Part 3) | ESAU | [esau-35](esau/1967/esau-35.md) | 206 | Top Secret | [PDF](https://www.cia.gov/readingroom/docs/esau-35.pdf) | 1967 |
 | The Sino-Soviet Struggle In The World Communist Movement Since Khrushchev'S Fall (Part 1) | ESAU | [esau-33](esau/1967/esau-33.md) | 197 | Top Secret | [PDF](https://www.cia.gov/readingroom/docs/esau-33.pdf) | 1967 |
 | The Sino-Soviet Struggle In The World Communist Movement Since Khrushchev'S Fall (Part 2) | ESAU | [esau-34](esau/1967/esau-34.md) | 161 | Top Secret | [PDF](https://www.cia.gov/readingroom/docs/esau-34.pdf) | 1967 |
 | Mao'S "Cultural Revolution": Origin And Development | POLO | [polo-14](polo/1967/polo-14.md) | 124 | Secret | [PDF](https://www.cia.gov/readingroom/docs/polo-14.pdf) | 1967 |
@@ -136,8 +134,7 @@ Since Khrushchev’S Fall (Part 3) | ESAU | [esau-35](esau/1967/esau-35.md) | 20
 | Red Guard And Revolutionary Rebel Organizations In Communist China (A Research Aid) | POLO | [polo-20](polo/1968/polo-20.md) | 71 | Top Secret | [PDF](https://www.cia.gov/readingroom/docs/polo-20.pdf) | 1968 |
 | Mao'S "Cultural Revolution" Iii. The Purge Of The P.L.A. And The Stardom Of Madame Mao | POLO | [polo-22](polo/1968/polo-22.md) | 83 | Top Secret | [PDF](https://www.cia.gov/readingroom/docs/polo-22.pdf) | 1968 |
 | Mao'S Red Guard Diplomacy: 1967 | POLO | [polo-21](polo/1968/polo-21.md) | 37 | Secret | [PDF](https://www.cia.gov/readingroom/docs/polo-21.pdf) | 1968 |
-| The Stalin Issue And
-The Soviet Leadership Struggle | CAESAR | [caesar-44](caesar/1968/caesar-44.md) | 18 | Secret | [PDF](https://www.cia.gov/readingroom/docs/caesar-44.pdf) | 1968 |
+| The Stalin Issue And The Soviet Leadership Struggle | CAESAR | [caesar-44](caesar/1968/caesar-44.md) | 18 | Secret | [PDF](https://www.cia.gov/readingroom/docs/caesar-44.pdf) | 1968 |
 | The Stalin Issue And The Soviet Leadership Struggle | CAESAR | [caesar-45](caesar/1968/caesar-45.md) | 146 | Secret | [PDF](https://www.cia.gov/readingroom/docs/caesar-45.pdf) | 1968 |
 | Factionalism In The Central Committee: Mao'S Opposition Since 1949 | POLO | [polo-23](polo/1968/polo-23.md) | 38 | CONFIDENTIAL | [PDF](https://www.cia.gov/readingroom/docs/polo-23.pdf) | 1968 |
 | The Sino-Soviet Dispute On Aid To North Vietnam (1965-1968) | ESAU | [esau-37](esau/1968/esau-37.md) | 33 | Top Secret | [PDF](https://www.cia.gov/readingroom/docs/esau-37.pdf) | 1968 |
@@ -158,8 +155,7 @@ The Soviet Leadership Struggle | CAESAR | [caesar-44](caesar/1968/caesar-44.md) 
 | Czechoslovakia: The Problem Of Soviet Control | ESAU | [esau-43](esau/1970/esau-43.md) | 66 | Top Secret | [PDF](https://www.cia.gov/readingroom/docs/esau-43.pdf) | 1970 |
 | Lin Piao And The Great Helmsman | POLO | [polo-29](polo/1970/polo-29.md) | 31 | Secret | [PDF](https://www.cia.gov/readingroom/docs/polo-29.pdf) | 1970 |
 | Soviet Policy And The 1967 Arab-Israeli War | CAESAR | [caesar-50](caesar/1970/caesar-50.md) | 71 | Top Secret | [PDF](https://www.cia.gov/readingroom/docs/caesar-50.pdf) | 1970 |
-| The Evolution Of Soviet Policy
-In The Sino-Sozliet Border Dispute | ESAU | [esau-44](esau/1970/esau-44.md) | 101 | Top Secret | [PDF](https://www.cia.gov/readingroom/docs/esau-44.pdf) | 1970 |
+| The Evolution Of Soviet Policy In The Sino-Sozliet Border Dispute | ESAU | [esau-44](esau/1970/esau-44.md) | 101 | Top Secret | [PDF](https://www.cia.gov/readingroom/docs/esau-44.pdf) | 1970 |
 | The Prussian Heresy: Ulbricht'S Evolving System | ESAU | [esau-45](esau/1970/esau-45.md) | 60 | Secret | [PDF](https://www.cia.gov/readingroom/docs/esau-45.pdf) | 1970 |
 | The Cultural Revolution And The New Political System In China | POLO | [polo-30](polo/1970/polo-30.md) | 29 | Secret | [PDF](https://www.cia.gov/readingroom/docs/polo-30.pdf) | 1970 |
 | Yugoslavia: The Outworn Structure | ESAU | [esau-46](esau/1970/esau-46.md) | 72 | Secret | [PDF](https://www.cia.gov/readingroom/docs/esau-46.pdf) | 1970 |

--- a/caesar/README.md
+++ b/caesar/README.md
@@ -45,8 +45,7 @@
 | The New Soviet Constitution And The Party-State Issue In Cpsu Politics, 1956-1966 | [caesar-41](./1966/caesar-41.md) | 113 | Secret | [PDF](https://www.cia.gov/readingroom/docs/caesar-41.pdf) | 1966 |
 | Strains In Soviet-East German Relations: 1962-1967 | [caesar-42](./1967/caesar-42.md) | 115 | SECRET | [PDF](https://www.cia.gov/readingroom/docs/caesar-42.pdf) | 1967 |
 | Policy And Politics In The Cpsu Politburo: October 1964 To September 1967 | [caesar-43](./1967/caesar-43.md) | 103 | Secret | [PDF](https://www.cia.gov/readingroom/docs/caesar-43.pdf) | 1967 |
-| The Stalin Issue And
-The Soviet Leadership Struggle | [caesar-44](./1968/caesar-44.md) | 18 | Secret | [PDF](https://www.cia.gov/readingroom/docs/caesar-44.pdf) | 1968 |
+| The Stalin Issue And The Soviet Leadership Struggle | [caesar-44](./1968/caesar-44.md) | 18 | Secret | [PDF](https://www.cia.gov/readingroom/docs/caesar-44.pdf) | 1968 |
 | The Stalin Issue And The Soviet Leadership Struggle | [caesar-45](./1968/caesar-45.md) | 146 | Secret | [PDF](https://www.cia.gov/readingroom/docs/caesar-45.pdf) | 1968 |
 | Politics In The Soviet Politburo And The Czech Crisis | [caesar-46](./1968/caesar-46.md) | 19 | Confidential | [PDF](https://www.cia.gov/readingroom/docs/caesar-46.pdf) | 1968 |
 | Institute For The Usa: The Kremlin'S New Approach To America-Watching | [caesar-47](./1969/caesar-47.md) | 44 | Secret | [PDF](https://www.cia.gov/readingroom/docs/caesar-47.pdf) | 1969 |

--- a/esau/README.md
+++ b/esau/README.md
@@ -34,9 +34,7 @@
 | Asian Communist Employment Of Negotiations As A Political Tactic | [esau-30](./1966/esau-30.md) | 55 | Secret | [PDF](https://www.cia.gov/readingroom/docs/esau-30.pdf) | 1966 |
 | The Disintegration Of Japanese Communist Relations With Peking | [esau-31](./1966/esau-31.md) | 77 | CONFIDENTIAL | [PDF](https://www.cia.gov/readingroom/docs/esau-31.pdf) | 1966 |
 | The Sino-Soviet Dispute Within The Communist Movement In Latin America | [esau-32](./1967/esau-32.md) | 187 | Top Secret | [PDF](https://www.cia.gov/readingroom/docs/esau-32.pdf) | 1967 |
-| The Sino-Soviet Struggle
-In The World Communist Movement
-Since Khrushchev’S Fall (Part 3) | [esau-35](./1967/esau-35.md) | 206 | Top Secret | [PDF](https://www.cia.gov/readingroom/docs/esau-35.pdf) | 1967 |
+| The Sino-Soviet Struggle In The World Communist Movement Since Khrushchev’S Fall (Part 3) | [esau-35](./1967/esau-35.md) | 206 | Top Secret | [PDF](https://www.cia.gov/readingroom/docs/esau-35.pdf) | 1967 |
 | The Sino-Soviet Struggle In The World Communist Movement Since Khrushchev'S Fall (Part 1) | [esau-33](./1967/esau-33.md) | 197 | Top Secret | [PDF](https://www.cia.gov/readingroom/docs/esau-33.pdf) | 1967 |
 | The Sino-Soviet Struggle In The World Communist Movement Since Khrushchev'S Fall (Part 2) | [esau-34](./1967/esau-34.md) | 161 | Top Secret | [PDF](https://www.cia.gov/readingroom/docs/esau-34.pdf) | 1967 |
 | The Attitudes Of North Vietnamese Leaders Toward Fighting And Negotiating | [esau-36](./1968/esau-36.md) | 64 | SECRET | [PDF](https://www.cia.gov/readingroom/docs/esau-36.pdf) | 1968 |
@@ -47,8 +45,7 @@ Since Khrushchev’S Fall (Part 3) | [esau-35](./1967/esau-35.md) | 206 | Top Se
 | The Struggle In The Polish Leadership And The Revolt Of The Apparat | [esau-41](./1969/esau-41.md) | 64 | Secret | [PDF](https://www.cia.gov/readingroom/docs/esau-41.pdf) | 1969 |
 | The Committed Church And Change In Latin America | [esau-42](./1969/esau-42.md) | 60 | SECRET | [PDF](https://www.cia.gov/readingroom/docs/esau-42.pdf) | 1969 |
 | Czechoslovakia: The Problem Of Soviet Control | [esau-43](./1970/esau-43.md) | 66 | Top Secret | [PDF](https://www.cia.gov/readingroom/docs/esau-43.pdf) | 1970 |
-| The Evolution Of Soviet Policy
-In The Sino-Sozliet Border Dispute | [esau-44](./1970/esau-44.md) | 101 | Top Secret | [PDF](https://www.cia.gov/readingroom/docs/esau-44.pdf) | 1970 |
+| The Evolution Of Soviet Policy In The Sino-Sozliet Border Dispute | [esau-44](./1970/esau-44.md) | 101 | Top Secret | [PDF](https://www.cia.gov/readingroom/docs/esau-44.pdf) | 1970 |
 | The Prussian Heresy: Ulbricht'S Evolving System | [esau-45](./1970/esau-45.md) | 60 | Secret | [PDF](https://www.cia.gov/readingroom/docs/esau-45.pdf) | 1970 |
 | Yugoslavia: The Outworn Structure | [esau-46](./1970/esau-46.md) | 72 | Secret | [PDF](https://www.cia.gov/readingroom/docs/esau-46.pdf) | 1970 |
 | Fedayeen -- "Men Of Sacrifice" | [esau-47](./1970/esau-47.md) | 55 | Top Secret | [PDF](https://www.cia.gov/readingroom/docs/esau-47.pdf) | 1970 |


### PR DESCRIPTION
### Motivation
- Several markdown table rows contained embedded newlines in their Title cells which broke single-line table rendering and made the tables harder to parse.
- The intent is to preserve the original metadata (links, page counts, classifications, years) while ensuring each table row is exactly one line so markdown renders correctly.

### Description
- Replaced multiline Title cells with single-line titles in `README.md`, `caesar/README.md`, and `esau/README.md` without changing any non-title fields.
- Fixed the entries for "The Sino-Soviet Struggle In The World Communist Movement Since Khrushchev’S Fall (Part 3)", "The Stalin Issue And The Soviet Leadership Struggle", and "The Evolution Of Soviet Policy In The Sino-Sozliet Border Dispute".
- Confirmed the edits are limited to title-cell flattening and committed the changes with message `Flatten multiline README table title cells`.

### Testing
- Ran a targeted search with `rg` to ensure the old multiline title starts are no longer present and the command returned no matches (success).
- Reviewed the patch with `git diff -- README.md caesar/README.md esau/README.md` to confirm only title wrapping changed (success).
- Inspected file excerpts with `nl` to verify each affected table row is now a single line and verified the commit with `git status --short` (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c684bf36248321a7a4af8a76dade05)