### PR TITLE
Normalize multiline titles in catalog, fix typo, and regenerate TOCs

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,9 +121,7 @@ The master catalog is **[`catalog/catalog.csv`](./catalog/catalog.csv)** with fi
 | Strains In Soviet-East German Relations: 1962-1967 | CAESAR | [caesar-42](caesar/1967/caesar-42.md) | 115 | SECRET | [PDF](https://www.cia.gov/readingroom/docs/caesar-42.pdf) | 1967 |
 | The Sino-Soviet Dispute Within The Communist Movement In Latin America | ESAU | [esau-32](esau/1967/esau-32.md) | 187 | Top Secret | [PDF](https://www.cia.gov/readingroom/docs/esau-32.pdf) | 1967 |
 | Policy And Politics In The Cpsu Politburo: October 1964 To September 1967 | CAESAR | [caesar-43](caesar/1967/caesar-43.md) | 103 | Secret | [PDF](https://www.cia.gov/readingroom/docs/caesar-43.pdf) | 1967 |
-| The Sino-Soviet Struggle
-In The World Communist Movement
-Since Khrushchev’S Fall (Part 3) | ESAU | [esau-35](esau/1967/esau-35.md) | 206 | Top Secret | [PDF](https://www.cia.gov/readingroom/docs/esau-35.pdf) | 1967 |
+| The Sino-Soviet Struggle In The World Communist Movement Since Khrushchev’S Fall (Part 3) | ESAU | [esau-35](esau/1967/esau-35.md) | 206 | Top Secret | [PDF](https://www.cia.gov/readingroom/docs/esau-35.pdf) | 1967 |
 | The Sino-Soviet Struggle In The World Communist Movement Since Khrushchev'S Fall (Part 1) | ESAU | [esau-33](esau/1967/esau-33.md) | 197 | Top Secret | [PDF](https://www.cia.gov/readingroom/docs/esau-33.pdf) | 1967 |
 | The Sino-Soviet Struggle In The World Communist Movement Since Khrushchev'S Fall (Part 2) | ESAU | [esau-34](esau/1967/esau-34.md) | 161 | Top Secret | [PDF](https://www.cia.gov/readingroom/docs/esau-34.pdf) | 1967 |
 | Mao'S "Cultural Revolution": Origin And Development | POLO | [polo-14](polo/1967/polo-14.md) | 124 | Secret | [PDF](https://www.cia.gov/readingroom/docs/polo-14.pdf) | 1967 |
@@ -136,8 +134,7 @@ Since Khrushchev’S Fall (Part 3) | ESAU | [esau-35](esau/1967/esau-35.md) | 20
 | Red Guard And Revolutionary Rebel Organizations In Communist China (A Research Aid) | POLO | [polo-20](polo/1968/polo-20.md) | 71 | Top Secret | [PDF](https://www.cia.gov/readingroom/docs/polo-20.pdf) | 1968 |
 | Mao'S "Cultural Revolution" Iii. The Purge Of The P.L.A. And The Stardom Of Madame Mao | POLO | [polo-22](polo/1968/polo-22.md) | 83 | Top Secret | [PDF](https://www.cia.gov/readingroom/docs/polo-22.pdf) | 1968 |
 | Mao'S Red Guard Diplomacy: 1967 | POLO | [polo-21](polo/1968/polo-21.md) | 37 | Secret | [PDF](https://www.cia.gov/readingroom/docs/polo-21.pdf) | 1968 |
-| The Stalin Issue And
-The Soviet Leadership Struggle | CAESAR | [caesar-44](caesar/1968/caesar-44.md) | 18 | Secret | [PDF](https://www.cia.gov/readingroom/docs/caesar-44.pdf) | 1968 |
+| The Stalin Issue And The Soviet Leadership Struggle | CAESAR | [caesar-44](caesar/1968/caesar-44.md) | 18 | Secret | [PDF](https://www.cia.gov/readingroom/docs/caesar-44.pdf) | 1968 |
 | The Stalin Issue And The Soviet Leadership Struggle | CAESAR | [caesar-45](caesar/1968/caesar-45.md) | 146 | Secret | [PDF](https://www.cia.gov/readingroom/docs/caesar-45.pdf) | 1968 |
 | Factionalism In The Central Committee: Mao'S Opposition Since 1949 | POLO | [polo-23](polo/1968/polo-23.md) | 38 | CONFIDENTIAL | [PDF](https://www.cia.gov/readingroom/docs/polo-23.pdf) | 1968 |
 | The Sino-Soviet Dispute On Aid To North Vietnam (1965-1968) | ESAU | [esau-37](esau/1968/esau-37.md) | 33 | Top Secret | [PDF](https://www.cia.gov/readingroom/docs/esau-37.pdf) | 1968 |
@@ -158,8 +155,7 @@ The Soviet Leadership Struggle | CAESAR | [caesar-44](caesar/1968/caesar-44.md) 
 | Czechoslovakia: The Problem Of Soviet Control | ESAU | [esau-43](esau/1970/esau-43.md) | 66 | Top Secret | [PDF](https://www.cia.gov/readingroom/docs/esau-43.pdf) | 1970 |
 | Lin Piao And The Great Helmsman | POLO | [polo-29](polo/1970/polo-29.md) | 31 | Secret | [PDF](https://www.cia.gov/readingroom/docs/polo-29.pdf) | 1970 |
 | Soviet Policy And The 1967 Arab-Israeli War | CAESAR | [caesar-50](caesar/1970/caesar-50.md) | 71 | Top Secret | [PDF](https://www.cia.gov/readingroom/docs/caesar-50.pdf) | 1970 |
-| The Evolution Of Soviet Policy
-In The Sino-Sozliet Border Dispute | ESAU | [esau-44](esau/1970/esau-44.md) | 101 | Top Secret | [PDF](https://www.cia.gov/readingroom/docs/esau-44.pdf) | 1970 |
+| The Evolution Of Soviet Policy In The Sino-Soviet Border Dispute | ESAU | [esau-44](esau/1970/esau-44.md) | 101 | Top Secret | [PDF](https://www.cia.gov/readingroom/docs/esau-44.pdf) | 1970 |
 | The Prussian Heresy: Ulbricht'S Evolving System | ESAU | [esau-45](esau/1970/esau-45.md) | 60 | Secret | [PDF](https://www.cia.gov/readingroom/docs/esau-45.pdf) | 1970 |
 | The Cultural Revolution And The New Political System In China | POLO | [polo-30](polo/1970/polo-30.md) | 29 | Secret | [PDF](https://www.cia.gov/readingroom/docs/polo-30.pdf) | 1970 |
 | Yugoslavia: The Outworn Structure | ESAU | [esau-46](esau/1970/esau-46.md) | 72 | Secret | [PDF](https://www.cia.gov/readingroom/docs/esau-46.pdf) | 1970 |

--- a/caesar/README.md
+++ b/caesar/README.md
@@ -45,8 +45,7 @@
 | The New Soviet Constitution And The Party-State Issue In Cpsu Politics, 1956-1966 | [caesar-41](./1966/caesar-41.md) | 113 | Secret | [PDF](https://www.cia.gov/readingroom/docs/caesar-41.pdf) | 1966 |
 | Strains In Soviet-East German Relations: 1962-1967 | [caesar-42](./1967/caesar-42.md) | 115 | SECRET | [PDF](https://www.cia.gov/readingroom/docs/caesar-42.pdf) | 1967 |
 | Policy And Politics In The Cpsu Politburo: October 1964 To September 1967 | [caesar-43](./1967/caesar-43.md) | 103 | Secret | [PDF](https://www.cia.gov/readingroom/docs/caesar-43.pdf) | 1967 |
-| The Stalin Issue And
-The Soviet Leadership Struggle | [caesar-44](./1968/caesar-44.md) | 18 | Secret | [PDF](https://www.cia.gov/readingroom/docs/caesar-44.pdf) | 1968 |
+| The Stalin Issue And The Soviet Leadership Struggle | [caesar-44](./1968/caesar-44.md) | 18 | Secret | [PDF](https://www.cia.gov/readingroom/docs/caesar-44.pdf) | 1968 |
 | The Stalin Issue And The Soviet Leadership Struggle | [caesar-45](./1968/caesar-45.md) | 146 | Secret | [PDF](https://www.cia.gov/readingroom/docs/caesar-45.pdf) | 1968 |
 | Politics In The Soviet Politburo And The Czech Crisis | [caesar-46](./1968/caesar-46.md) | 19 | Confidential | [PDF](https://www.cia.gov/readingroom/docs/caesar-46.pdf) | 1968 |
 | Institute For The Usa: The Kremlin'S New Approach To America-Watching | [caesar-47](./1969/caesar-47.md) | 44 | Secret | [PDF](https://www.cia.gov/readingroom/docs/caesar-47.pdf) | 1969 |

--- a/caesar/_index.md
+++ b/caesar/_index.md
@@ -47,8 +47,7 @@ _Single-table view generated from `catalog/catalog.csv`._
 | The New Soviet Constitution And The Party-State Issue In Cpsu Politics, 1956-1966 | [caesar-41](./1966/caesar-41.md) | 113 | Secret | [PDF](https://www.cia.gov/readingroom/docs/caesar-41.pdf) | 1966 |
 | Strains In Soviet-East German Relations: 1962-1967 | [caesar-42](./1967/caesar-42.md) | 115 | SECRET | [PDF](https://www.cia.gov/readingroom/docs/caesar-42.pdf) | 1967 |
 | Policy And Politics In The Cpsu Politburo: October 1964 To September 1967 | [caesar-43](./1967/caesar-43.md) | 103 | Secret | [PDF](https://www.cia.gov/readingroom/docs/caesar-43.pdf) | 1967 |
-| The Stalin Issue And
-The Soviet Leadership Struggle | [caesar-44](./1968/caesar-44.md) | 18 | Secret | [PDF](https://www.cia.gov/readingroom/docs/caesar-44.pdf) | 1968 |
+| The Stalin Issue And The Soviet Leadership Struggle | [caesar-44](./1968/caesar-44.md) | 18 | Secret | [PDF](https://www.cia.gov/readingroom/docs/caesar-44.pdf) | 1968 |
 | The Stalin Issue And The Soviet Leadership Struggle | [caesar-45](./1968/caesar-45.md) | 146 | Secret | [PDF](https://www.cia.gov/readingroom/docs/caesar-45.pdf) | 1968 |
 | Politics In The Soviet Politburo And The Czech Crisis | [caesar-46](./1968/caesar-46.md) | 19 | Confidential | [PDF](https://www.cia.gov/readingroom/docs/caesar-46.pdf) | 1968 |
 | Institute For The Usa: The Kremlin'S New Approach To America-Watching | [caesar-47](./1969/caesar-47.md) | 44 | Secret | [PDF](https://www.cia.gov/readingroom/docs/caesar-47.pdf) | 1969 |

--- a/catalog/catalog.csv
+++ b/catalog/catalog.csv
@@ -77,8 +77,7 @@ The Cultural Revolution And Education In Communist China,1969-05-23,RSS,https://
 The Cultural Revolution And The New Political System In China,1970-10-30,RSS,https://www.cia.gov/readingroom/docs/polo-30.pdf,29,Secret,polo-30.pdf
 The Cultural Revolution And The Ninth Party Congress,1969-10-01,RSS,https://www.cia.gov/readingroom/docs/polo-27.pdf,40,SECRET,polo-27.pdf
 The Disintegration Of Japanese Communist Relations With Peking,1966-12-28,RSS,https://www.cia.gov/readingroom/docs/esau-31.pdf,77,CONFIDENTIAL,esau-31.pdf
-"The Evolution Of Soviet Policy
-In The Sino-Sozliet Border Dispute ",1970-04-28,RSS,https://www.cia.gov/readingroom/docs/esau-44.pdf,101,Top Secret,esau-44.pdf
+The Evolution Of Soviet Policy In The Sino-Soviet Border Dispute,1970-04-28,RSS,https://www.cia.gov/readingroom/docs/esau-44.pdf,101,Top Secret,esau-44.pdf
 The Failure Of Maoist Ideology In Foreign Policy,1971-11-01,RSS,https://www.cia.gov/readingroom/docs/polo-32.pdf,11,Secret,polo-32.pdf
 The Growth Of The Soviet Commitment In The Middle East,1971-01-01,UNKNOWN,https://www.cia.gov/readingroom/docs/esau-48.pdf,182,Top Secret,esau-48.pdf
 The International Liaison Department Of The Chinese Communist Party,1971-12-01,RSS,https://www.cia.gov/readingroom/docs/polo-33.pdf,37,Secret,polo-33.pdf
@@ -92,11 +91,8 @@ The Sino-Soviet Dispute On Aid To North Vietnam (1965-1968),1968-09-30,UNKNOWN,h
 The Sino-Soviet Dispute Within The Communist Movement In Latin America,1967-06-15,UNKNOWN,https://www.cia.gov/readingroom/docs/esau-32.pdf,187,Top Secret,esau-32.pdf
 The Sino-Soviet Struggle In The World Communist Movement Since Khrushchev'S Fall (Part 1),1967-09-01,RSS,https://www.cia.gov/readingroom/docs/esau-33.pdf,197,Top Secret,esau-33.pdf
 The Sino-Soviet Struggle In The World Communist Movement Since Khrushchev'S Fall (Part 2),1967-09-01,RSS,https://www.cia.gov/readingroom/docs/esau-34.pdf,161,Top Secret,esau-34.pdf
-"The Sino-Soviet Struggle
-In The World Communist Movement
-Since Khrushchev’S Fall (Part 3) ",1967-09-01,RSS,https://www.cia.gov/readingroom/docs/esau-35.pdf,206,Top Secret,esau-35.pdf
-"The Stalin Issue And
-The Soviet Leadership Struggle",1968-07-05,RSS,https://www.cia.gov/readingroom/docs/caesar-44.pdf,18,Secret,caesar-44.pdf
+The Sino-Soviet Struggle In The World Communist Movement Since Khrushchev’S Fall (Part 3),1967-09-01,RSS,https://www.cia.gov/readingroom/docs/esau-35.pdf,206,Top Secret,esau-35.pdf
+The Stalin Issue And The Soviet Leadership Struggle,1968-07-05,RSS,https://www.cia.gov/readingroom/docs/caesar-44.pdf,18,Secret,caesar-44.pdf
 The Struggle In The Polish Leadership And The Revolt Of The Apparat,1969-09-05,RSS,https://www.cia.gov/readingroom/docs/esau-41.pdf,64,Secret,esau-41.pdf
 Yugoslavia: The Outworn Structure,1970-11-20,RSS,https://www.cia.gov/readingroom/docs/esau-46.pdf,72,Secret,esau-46.pdf
 Khrushchev'S Role In The Current Controversy Over Soviet Defense Policy,1963-06-17,OCI,https://www.cia.gov/readingroom/docs/caesar-33.pdf,28,Secret,caesar-33.pdf

--- a/esau/1970/esau-44.md
+++ b/esau/1970/esau-44.md
@@ -1,6 +1,6 @@
 ---
 id: esau-44
-title: The Evolution Of Soviet Policy In The Sino-Sozliet Border Dispute
+title: The Evolution Of Soviet Policy In The Sino-Soviet Border Dispute
 publication_date: '1970-04-28'
 producing_office: RSS
 original_classification: Top Secret

--- a/esau/README.md
+++ b/esau/README.md
@@ -34,9 +34,7 @@
 | Asian Communist Employment Of Negotiations As A Political Tactic | [esau-30](./1966/esau-30.md) | 55 | Secret | [PDF](https://www.cia.gov/readingroom/docs/esau-30.pdf) | 1966 |
 | The Disintegration Of Japanese Communist Relations With Peking | [esau-31](./1966/esau-31.md) | 77 | CONFIDENTIAL | [PDF](https://www.cia.gov/readingroom/docs/esau-31.pdf) | 1966 |
 | The Sino-Soviet Dispute Within The Communist Movement In Latin America | [esau-32](./1967/esau-32.md) | 187 | Top Secret | [PDF](https://www.cia.gov/readingroom/docs/esau-32.pdf) | 1967 |
-| The Sino-Soviet Struggle
-In The World Communist Movement
-Since Khrushchev’S Fall (Part 3) | [esau-35](./1967/esau-35.md) | 206 | Top Secret | [PDF](https://www.cia.gov/readingroom/docs/esau-35.pdf) | 1967 |
+| The Sino-Soviet Struggle In The World Communist Movement Since Khrushchev’S Fall (Part 3) | [esau-35](./1967/esau-35.md) | 206 | Top Secret | [PDF](https://www.cia.gov/readingroom/docs/esau-35.pdf) | 1967 |
 | The Sino-Soviet Struggle In The World Communist Movement Since Khrushchev'S Fall (Part 1) | [esau-33](./1967/esau-33.md) | 197 | Top Secret | [PDF](https://www.cia.gov/readingroom/docs/esau-33.pdf) | 1967 |
 | The Sino-Soviet Struggle In The World Communist Movement Since Khrushchev'S Fall (Part 2) | [esau-34](./1967/esau-34.md) | 161 | Top Secret | [PDF](https://www.cia.gov/readingroom/docs/esau-34.pdf) | 1967 |
 | The Attitudes Of North Vietnamese Leaders Toward Fighting And Negotiating | [esau-36](./1968/esau-36.md) | 64 | SECRET | [PDF](https://www.cia.gov/readingroom/docs/esau-36.pdf) | 1968 |
@@ -47,8 +45,7 @@ Since Khrushchev’S Fall (Part 3) | [esau-35](./1967/esau-35.md) | 206 | Top Se
 | The Struggle In The Polish Leadership And The Revolt Of The Apparat | [esau-41](./1969/esau-41.md) | 64 | Secret | [PDF](https://www.cia.gov/readingroom/docs/esau-41.pdf) | 1969 |
 | The Committed Church And Change In Latin America | [esau-42](./1969/esau-42.md) | 60 | SECRET | [PDF](https://www.cia.gov/readingroom/docs/esau-42.pdf) | 1969 |
 | Czechoslovakia: The Problem Of Soviet Control | [esau-43](./1970/esau-43.md) | 66 | Top Secret | [PDF](https://www.cia.gov/readingroom/docs/esau-43.pdf) | 1970 |
-| The Evolution Of Soviet Policy
-In The Sino-Sozliet Border Dispute | [esau-44](./1970/esau-44.md) | 101 | Top Secret | [PDF](https://www.cia.gov/readingroom/docs/esau-44.pdf) | 1970 |
+| The Evolution Of Soviet Policy In The Sino-Soviet Border Dispute | [esau-44](./1970/esau-44.md) | 101 | Top Secret | [PDF](https://www.cia.gov/readingroom/docs/esau-44.pdf) | 1970 |
 | The Prussian Heresy: Ulbricht'S Evolving System | [esau-45](./1970/esau-45.md) | 60 | Secret | [PDF](https://www.cia.gov/readingroom/docs/esau-45.pdf) | 1970 |
 | Yugoslavia: The Outworn Structure | [esau-46](./1970/esau-46.md) | 72 | Secret | [PDF](https://www.cia.gov/readingroom/docs/esau-46.pdf) | 1970 |
 | Fedayeen -- "Men Of Sacrifice" | [esau-47](./1970/esau-47.md) | 55 | Top Secret | [PDF](https://www.cia.gov/readingroom/docs/esau-47.pdf) | 1970 |

--- a/esau/_index.md
+++ b/esau/_index.md
@@ -36,9 +36,7 @@ _Single-table view generated from `catalog/catalog.csv`._
 | Asian Communist Employment Of Negotiations As A Political Tactic | [esau-30](./1966/esau-30.md) | 55 | Secret | [PDF](https://www.cia.gov/readingroom/docs/esau-30.pdf) | 1966 |
 | The Disintegration Of Japanese Communist Relations With Peking | [esau-31](./1966/esau-31.md) | 77 | CONFIDENTIAL | [PDF](https://www.cia.gov/readingroom/docs/esau-31.pdf) | 1966 |
 | The Sino-Soviet Dispute Within The Communist Movement In Latin America | [esau-32](./1967/esau-32.md) | 187 | Top Secret | [PDF](https://www.cia.gov/readingroom/docs/esau-32.pdf) | 1967 |
-| The Sino-Soviet Struggle
-In The World Communist Movement
-Since Khrushchev’S Fall (Part 3) | [esau-35](./1967/esau-35.md) | 206 | Top Secret | [PDF](https://www.cia.gov/readingroom/docs/esau-35.pdf) | 1967 |
+| The Sino-Soviet Struggle In The World Communist Movement Since Khrushchev’S Fall (Part 3) | [esau-35](./1967/esau-35.md) | 206 | Top Secret | [PDF](https://www.cia.gov/readingroom/docs/esau-35.pdf) | 1967 |
 | The Sino-Soviet Struggle In The World Communist Movement Since Khrushchev'S Fall (Part 1) | [esau-33](./1967/esau-33.md) | 197 | Top Secret | [PDF](https://www.cia.gov/readingroom/docs/esau-33.pdf) | 1967 |
 | The Sino-Soviet Struggle In The World Communist Movement Since Khrushchev'S Fall (Part 2) | [esau-34](./1967/esau-34.md) | 161 | Top Secret | [PDF](https://www.cia.gov/readingroom/docs/esau-34.pdf) | 1967 |
 | The Attitudes Of North Vietnamese Leaders Toward Fighting And Negotiating | [esau-36](./1968/esau-36.md) | 64 | SECRET | [PDF](https://www.cia.gov/readingroom/docs/esau-36.pdf) | 1968 |
@@ -49,8 +47,7 @@ Since Khrushchev’S Fall (Part 3) | [esau-35](./1967/esau-35.md) | 206 | Top Se
 | The Struggle In The Polish Leadership And The Revolt Of The Apparat | [esau-41](./1969/esau-41.md) | 64 | Secret | [PDF](https://www.cia.gov/readingroom/docs/esau-41.pdf) | 1969 |
 | The Committed Church And Change In Latin America | [esau-42](./1969/esau-42.md) | 60 | SECRET | [PDF](https://www.cia.gov/readingroom/docs/esau-42.pdf) | 1969 |
 | Czechoslovakia: The Problem Of Soviet Control | [esau-43](./1970/esau-43.md) | 66 | Top Secret | [PDF](https://www.cia.gov/readingroom/docs/esau-43.pdf) | 1970 |
-| The Evolution Of Soviet Policy
-In The Sino-Sozliet Border Dispute | [esau-44](./1970/esau-44.md) | 101 | Top Secret | [PDF](https://www.cia.gov/readingroom/docs/esau-44.pdf) | 1970 |
+| The Evolution Of Soviet Policy In The Sino-Soviet Border Dispute | [esau-44](./1970/esau-44.md) | 101 | Top Secret | [PDF](https://www.cia.gov/readingroom/docs/esau-44.pdf) | 1970 |
 | The Prussian Heresy: Ulbricht'S Evolving System | [esau-45](./1970/esau-45.md) | 60 | Secret | [PDF](https://www.cia.gov/readingroom/docs/esau-45.pdf) | 1970 |
 | Yugoslavia: The Outworn Structure | [esau-46](./1970/esau-46.md) | 72 | Secret | [PDF](https://www.cia.gov/readingroom/docs/esau-46.pdf) | 1970 |
 | Fedayeen -- "Men Of Sacrifice" | [esau-47](./1970/esau-47.md) | 55 | Top Secret | [PDF](https://www.cia.gov/readingroom/docs/esau-47.pdf) | 1970 |


### PR DESCRIPTION
### Motivation
- Prevent broken table rows and TOC generation errors by ensuring `title` values in the master catalog are single-line strings without embedded newlines or stray trailing spaces.
- Correct an OCR/metadata typo (`Sino-Sozliet`) to the confirmed source title `Sino-Soviet` so the document frontmatter and generated tables match the PDF metadata.
- Regenerate README/TOC outputs so the cleaned catalog does not reintroduce the multiline artifacts in rendered views.

### Description
- Cleaned `catalog/catalog.csv` by replacing embedded newlines and trimming trailing spaces for the affected entries: `esau-35`, `esau-44`, and `caesar-44` so their `title` fields are single-line values.
- Fixed the `esau-44` frontmatter title in `esau/1970/esau-44.md` from `Sino-Sozliet` to `Sino-Soviet` to match the source transcription/title page.
- Regenerated updated TOC/table rows in `README.md`, `caesar/README.md`, and `esau/README.md` and synchronized the generated `_index.md` views for `caesar` and `esau` to reflect the cleaned catalog.
- Ensured the three affected catalog entries now appear as single-line titles in both the CSV and the generated markdown tables.

### Testing
- Parsed `catalog/catalog.csv` with `csv.DictReader` and asserted no `\n` or `\r` remain in any `title` field, and the check passed.
- Asserted exact corrected title values for `esau-35.pdf`, `esau-44.pdf`, and `caesar-44.pdf` via a Python validation script, and the assertions passed.
- Searched repository files with `rg` to confirm no remaining `Sino-Sozliet` occurrences or split-title table rows in `README`/index files, and the search returned no remaining issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c684cc7ad08321a5657753c3c8fec7)